### PR TITLE
Fix: rails db:setup時に失敗する

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -30,6 +30,7 @@ development:
 test:
   <<: *default
   database: neo_otaku_word_test
+  port: 15432
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
原因: テスト時のDBのポート番号の指定が間違っていた

これでRspec実行できる