### PR TITLE
Fix: テスト時のポート番号をデフォルトの5432に設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -30,8 +30,6 @@ development:
 test:
   <<: *default
   database: neo_otaku_word_test
-  port: 15432
-
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.


### PR DESCRIPTION
## やったこと
- ローカルのpostgresに`root`ユーザーを追加
- パスワードを'password'に設定
- 追加したユーザー `root`に権限を付与
```
ALTER ROLE root WITH CREATEDB CREATEROLE;
rootユーザーにCREATEDBとCREATEROLEの権限を与える
```
- テスト時は5432ポートに接続するように変更するため、`database.yml`を編集
```
test:
  <<: *default
  database: neo_otaku_word_test
# port: 15432 を削除
```