### PR TITLE
Fix: $ rails db:seed時に、用語が重複してしまう

### DIFF
--- a/db/data/categories.rb
+++ b/db/data/categories.rb
@@ -9,6 +9,6 @@ categories = [
 ]
 
 categories.each do |category|
-  Category.create(category)
+  Category.find_or_create_by!(category)
   print '.'
 end

--- a/db/data/words.rb
+++ b/db/data/words.rb
@@ -23,7 +23,7 @@ words = [
 ]
 
 words.each do |word_attr|
-  word = OtakuWord.new(word_attr[:base])
+  word = OtakuWord.find_or_initialize_by(word_attr[:base])
   word.categories = word_attr[:relation]
   word.save!
   print '.'


### PR DESCRIPTION
対策: find_or_create_by, find_or_initialize_byに変更